### PR TITLE
Rewrite plugin for 0.13.0, extend modifiers

### DIFF
--- a/BeatSaberDiscordPresence/BeatSaberDiscordPresence.csproj
+++ b/BeatSaberDiscordPresence/BeatSaberDiscordPresence.csproj
@@ -59,9 +59,7 @@
     <Compile Include="DiscordRpc.cs" />
     <Compile Include="Plugin.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SetupDataExtensions.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Target Name="AfterBuild">
-    <Copy SourceFiles="$(OutputPath)BeatSaberDiscordPresence.dll" DestinationFolder="C:\Program Files (x86)\Steam\steamapps\common\Beat Saber\Plugins\" ContinueOnError="true" />
-  </Target>
 </Project>

--- a/BeatSaberDiscordPresence/Properties/AssemblyInfo.cs
+++ b/BeatSaberDiscordPresence/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.0.2.0")]
-[assembly: AssemblyFileVersion("2.0.2.0")]
+[assembly: AssemblyVersion("2.1.0.0")]
+[assembly: AssemblyFileVersion("2.1.0.0")]

--- a/BeatSaberDiscordPresence/SetupDataExtensions.cs
+++ b/BeatSaberDiscordPresence/SetupDataExtensions.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BeatSaberDiscordPresence
+{
+    static class SetupDataExtensions
+    {
+        private static readonly List<Func<GameplayCoreSceneSetupData, string>> mapping = new List<Func<GameplayCoreSceneSetupData, string>>
+        {
+            s => s.difficultyBeatmap.parentDifficultyBeatmapSet.beatmapCharacteristic.hintText,
+            s => s.practiceSettings != null ? "Practice" : "",
+            s => s.difficultyBeatmap.level.levelID.Contains('∎') ? "Custom" : "",
+            s => s.gameplayModifiers.batteryEnergy ? "Battery" : "",
+            s => s.gameplayModifiers.disappearingArrows ? "Disappearing Arrows" : "",
+            s => s.gameplayModifiers.ghostNotes ? "Ghost Notes" : "",
+            s => s.gameplayModifiers.instaFail ? "InstaFail" : "",
+            s => s.gameplayModifiers.songSpeed == GameplayModifiers.SongSpeed.Faster ? "Faster" : "",
+            s => s.gameplayModifiers.songSpeed == GameplayModifiers.SongSpeed.Faster ? "Slower" : "",
+            s => s.gameplayModifiers.noObstacles ? "No Walls" : "",
+            s => s.gameplayModifiers.noBombs ? "No Bombs" : "",
+            s => s.gameplayModifiers.noFail ? "No Fail" : ""
+        };
+
+        internal static string GetModifiers(this GameplayCoreSceneSetupData setup)
+        {
+            return string.Join(" | ", mapping.Select(fn => fn(setup)).Where(s => s.Length > 0));
+        }
+
+        internal static string GetGameplayModeImage(this GameplayCoreSceneSetupData setup)
+        {
+            switch (setup.difficultyBeatmap.parentDifficultyBeatmapSet.beatmapCharacteristic.hintText)
+            {
+                case "No Arrows":
+                    return "no_arrows";
+                case "One Saber":
+                    return "one_saber";
+                default:
+                    return "solo";
+            }
+        }
+    }
+}


### PR DESCRIPTION
Hi! First of all, thanks for this plugin, it's been doing great service with earlier versions of Beat Saber.

With 0.13.0, it seems things have been shuffled around again. This PR makes the plugin compatible with the new version, and adds some flair to the displayed presence as all kinds of info is available from GameplayCoreSceneSetupData.

It would be pretty slick if you could review it, and perhaps push it to modsaber.org.
EDIT: well, never mind the last part, another fork is up.

---

(PS: big thanks to Slaynash and Rolo on BSMG for pushing me in the right direction instead of Harmony.)